### PR TITLE
Hotfix: eliminar de carrito

### DIFF
--- a/restapi/modelos/productoModelo.ts
+++ b/restapi/modelos/productoModelo.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { ObjectId } from 'mongoose';
 
 interface IProducto {
     referencia:String;
@@ -11,6 +12,7 @@ interface IProducto {
   }
 
   interface ProductoDoc extends mongoose.Document {
+    _id: ObjectId;
     referencia:String;
     marca:String;
     modelo: String;

--- a/restapi/rutas/productoRutas.ts
+++ b/restapi/rutas/productoRutas.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import { Producto , ProductoDoc} from '../modelos/productoModelo';
 import consultarREST from './consultarREST';
 import "dotenv/config";
+import { ObjectId } from 'mongoose';
 
 const router = express.Router()
 //Recuperamos todos los colores asociados a un producto facilitando su referencia
@@ -63,6 +64,7 @@ router.get('/producto/detalles/tallas_disponibles/:referencia', async (req: Requ
 router.get('/products/list', async (req: Request, res: Response) => {
   //formato de salida que espera el front-end
   type TypeProduct = {
+    _objectId: ObjectId;
     id: String;
     nombre: String;
     precio: Number;
@@ -76,7 +78,7 @@ router.get('/products/list', async (req: Request, res: Response) => {
   for (var i=0; i< productos.length; i++)
   {
       let entrada = productos[i];
-      let salida: TypeProduct = ({ id: "", nombre:"",precio:0,imagen: "" });
+      let salida: TypeProduct = ({ _objectId: entrada._id, id: "", nombre:"",precio:0,imagen: "" });
       salida.id = entrada.referencia;
       salida.nombre = entrada.marca + " " +entrada.modelo;
       salida.precio = entrada.precio
@@ -102,6 +104,7 @@ router.post('/products/add', async (req: Request, res: Response) => {
 router.get('/producto/detalles/:referencia', async (req: Request, res: Response) => {
   //formato de salida que espera el front-end
   type TypeProduct = {
+    _objectId: ObjectId;
     id: String;
     nombre: String;
     precio: Number;
@@ -116,7 +119,7 @@ router.get('/producto/detalles/:referencia', async (req: Request, res: Response)
   const product = await Producto.findOne({referencia: ref})
   if(product){
     let entrada = product;
-    let salida: TypeProduct = ({ id: "", nombre:"",precio:0,descripcion:"",imagen: "" });
+    let salida: TypeProduct = ({ _objectId: entrada._id, id: "", nombre:"",precio:0,descripcion:"",imagen: "" });
     salida.id = entrada.referencia;
     salida.nombre = entrada.marca + " " +entrada.modelo;
     salida.precio = entrada.precio

--- a/webapp/src/components/Cart/ShoesCart.tsx
+++ b/webapp/src/components/Cart/ShoesCart.tsx
@@ -34,7 +34,6 @@ const useStyles = makeStyles({
 const ShoesCart = () => {
   const classes = useStyles();
     const carrito = JSON.parse(sessionStorage.getItem('cart') as string);
-    console.log(carrito);
     return (
       <Container maxWidth="md" className={classes.colores2}>
         <Typography variant='h3' className={classes.colores}>
@@ -66,7 +65,7 @@ const ShoesCart = () => {
             {
               // Eliminar de carrito
               var newCart = carrito.filter(function (cartProduct:TypeProduct) {     // Eliminamos el producto que tenga todas las propiedades iguales al buscado
-                return (cartProduct.id != item.id && cartProduct.nombre != item.nombre && cartProduct.precio != item.precio && cartProduct.imagen != item.imagen);
+                return (cartProduct._objectId != item._objectId);
               });
               sessionStorage.setItem('cart', JSON.stringify(newCart));
               window.location.reload();   // Recargamos la pagina

--- a/webapp/src/components/Details/RightDetails.tsx
+++ b/webapp/src/components/Details/RightDetails.tsx
@@ -27,7 +27,7 @@ type parsedProduct = {
 const RightDetails = (parsed:parsedProduct) => {
   
   function addToCart(){
-    const item = {"id":parsed.product[0].id,"nombre":parsed.product[0].nombre,"precio":parsed.product[0].precio,"imagen":parsed.product[0].imagen};
+    const item = {"_objectId":parsed.product[0]._objectId,"id":parsed.product[0].id,"nombre":parsed.product[0].nombre,"precio":parsed.product[0].precio,"imagen":parsed.product[0].imagen};
     var cart:string = sessionStorage.getItem('cart') as string;
     if(JSON.parse(cart).length > 0){
       var newCart:string = cart.substring(0, cart.length-1) + ',' + JSON.stringify(item) + ']';

--- a/webapp/src/shared/shareddtypes.ts
+++ b/webapp/src/shared/shareddtypes.ts
@@ -1,4 +1,4 @@
-import { ShorthandPropertyAssignment } from "typescript";
+import { ObjectId } from 'mongoose';
 
 export type User = {
     name:string;
@@ -11,6 +11,7 @@ export type Product = {
 }
 
 export type TypeProduct = {
+  _objectId: ObjectId;
   id: string;
   nombre: string;
   precio: number;


### PR DESCRIPTION
Se ha solucionado un error que se producía al intentar eliminar un artículo del carrito cuando se había encargado más de 1 unidad de dicho producto.